### PR TITLE
Corrigir posição e frame do oponente

### DIFF
--- a/code/cena1.js
+++ b/code/cena1.js
@@ -517,14 +517,14 @@ cena1.update = function () {
       player1.anims.play("killed1", true);
     }
     try {
-      frame = player1.anims.currentFrame.index;
+      frame = player1.anims.getFrameName();
     } catch (e) {
       frame = 0;
     }
     socket.emit("estadoDoJogador", {
       frame: frame,
-      x: player1.body.x,
-      y: player1.body.y,
+      x: player1.body.x + 16,
+      y: player1.body.y + 16,
     });
   } else if (jogador === 2) {
     // Controle do personagem 2: direcionais
@@ -576,14 +576,14 @@ cena1.update = function () {
       }
     }
     try {
-      frame = player2.anims.currentFrame.index;
+      frame = player2.anims.getFrameName();
     } catch (e) {
       frame = 0;
     }
     socket.emit("estadoDoJogador", {
       frame: frame,
-      x: player2.body.x,
-      y: player2.body.y,
+      x: player2.body.x + 16,
+      y: player2.body.y + 16,
     });
   }
 };


### PR DESCRIPTION
Duas correções:

1. Deslocados X e Y do oponente para compensar o processamento do Phaser: _sprite_ local é posicionado com base no centro, oponente remoto é posicionado com base no canto superior direito. Como os personagens são 32x32, o deslocamento é de metade (16) em cada eixo.
2. Nesta versão do Phaser (`3.55.2`) já existe o método `anims.GetFrameName()`para obter o índice do _frame_ em uso na animação, de forma que possa ser enviada para o oponente.